### PR TITLE
Use proper `Sync.blocking` for things that block

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.14"
+ThisBuild / tlBaseVersion := "0.15"
 
 ThisBuild / organization := "dev.scalafreaks"
 ThisBuild / organizationName := "ScalaFreaks"

--- a/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
@@ -28,7 +28,7 @@ case class ConsoleLogger[F[_]](
     out: PrintStream,
     err: PrintStream,
     override val minLevel: Level,
-    syncType: Sync.Type = Sync.Type.Blocking
+    syncType: Sync.Type
 )(implicit F: Sync[F])
     extends DefaultLogger[F](minLevel) {
   private def println(out: PrintStream, msg: LoggerMessage, formatter: Formatter): F[Unit] =
@@ -45,6 +45,6 @@ case class ConsoleLogger[F[_]](
 }
 
 object ConsoleLogger {
-  def apply[F[_]: Sync](formatter: Formatter, minLevel: Level): Logger[F] =
-    ConsoleLogger(formatter, scala.Console.out, scala.Console.err, minLevel)
+  def apply[F[_]: Sync](formatter: Formatter, minLevel: Level, syncType: Sync.Type = Sync.Type.Blocking): Logger[F] =
+    ConsoleLogger(formatter, scala.Console.out, scala.Console.err, minLevel, syncType)
 }

--- a/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
@@ -27,11 +27,12 @@ case class ConsoleLogger[F[_]](
     formatter: Formatter,
     out: PrintStream,
     err: PrintStream,
-    override val minLevel: Level
+    override val minLevel: Level,
+    syncType: Sync.Type = Sync.Type.Blocking
 )(implicit F: Sync[F])
     extends DefaultLogger[F](minLevel) {
   private def println(out: PrintStream, msg: LoggerMessage, formatter: Formatter): F[Unit] =
-    F.delay(out.println(formatter.format(msg)))
+    F.suspend(syncType)(out.println(formatter.format(msg)))
 
   def submit(msg: LoggerMessage): F[Unit] =
     if (msg.level < Level.Warn) {

--- a/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
@@ -132,7 +132,7 @@ object RollingFileLogger {
         for {
           size <-
             if (maxFileSizeInBytes.isDefined) {
-              F.delay(fileSizeCheck(filePath))
+              F.blocking(fileSizeCheck(filePath))
             } else {
               F.pure(0L)
             }

--- a/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
@@ -17,11 +17,11 @@
 package io.odin.loggers
 
 import java.io.{ByteArrayOutputStream, PrintStream}
-
 import cats.effect.IO
+import cats.effect.kernel.Sync
 import cats.effect.unsafe.IORuntime
-import cats.syntax.all._
-import io.odin.Level._
+import cats.syntax.all.*
+import io.odin.Level.*
 import io.odin.formatter.Formatter
 import io.odin.{Level, LoggerMessage, OdinSpec}
 
@@ -37,7 +37,7 @@ class ConsoleLoggerSpec extends OdinSpec {
         val errBaos = new ByteArrayOutputStream()
         val stdErr = new PrintStream(errBaos)
 
-        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace)
+        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
         consoleLogger.log(loggerMessage).unsafeRunSync()
         outBaos.toString() shouldBe (formatter.format(loggerMessage) + System.lineSeparator())
       }
@@ -52,7 +52,7 @@ class ConsoleLoggerSpec extends OdinSpec {
         val errBaos = new ByteArrayOutputStream()
         val stdErr = new PrintStream(errBaos)
 
-        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace)
+        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
         consoleLogger.log(loggerMessage).unsafeRunSync()
         errBaos.toString() shouldBe (formatter.format(loggerMessage) + System.lineSeparator())
       }

--- a/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
@@ -23,16 +23,20 @@ import io.odin.{Level, Logger, LoggerMessage}
 import org.slf4j.{Logger => JLogger, LoggerFactory}
 import cats.implicits._
 
-final class Slf4jLogger[F[_]: Sync](logger: JLogger, level: Level, formatter: Formatter)
-    extends DefaultLogger[F](level) {
+final class Slf4jLogger[F[_]: Sync](
+    logger: JLogger,
+    level: Level,
+    formatter: Formatter,
+    syncType: Sync.Type = Sync.Type.Blocking
+) extends DefaultLogger[F](level) {
   override def submit(msg: LoggerMessage): F[Unit] = {
     Sync[F].uncancelable { _ =>
       Sync[F].whenA(msg.level >= this.minLevel)(msg.level match {
-        case Level.Trace => Sync[F].delay(logger.trace(formatter.format(msg)))
-        case Level.Debug => Sync[F].delay(logger.debug(formatter.format(msg)))
-        case Level.Info  => Sync[F].delay(logger.info(formatter.format(msg)))
-        case Level.Warn  => Sync[F].delay(logger.warn(formatter.format(msg)))
-        case Level.Error => Sync[F].delay(logger.error(formatter.format(msg)))
+        case Level.Trace => Sync[F].suspend(syncType)(logger.trace(formatter.format(msg)))
+        case Level.Debug => Sync[F].suspend(syncType)(logger.debug(formatter.format(msg)))
+        case Level.Info  => Sync[F].suspend(syncType)(logger.info(formatter.format(msg)))
+        case Level.Warn  => Sync[F].suspend(syncType)(logger.warn(formatter.format(msg)))
+        case Level.Error => Sync[F].suspend(syncType)(logger.error(formatter.format(msg)))
       })
     }
   }

--- a/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
@@ -41,7 +41,7 @@ final class Slf4jLogger[F[_]: Sync](
     }
   }
 
-  override def withMinimalLevel(level: Level): Logger[F] = new Slf4jLogger[F](logger, level, formatter)
+  override def withMinimalLevel(level: Level): Logger[F] = new Slf4jLogger[F](logger, level, formatter, syncType)
 }
 
 object Slf4jLogger {

--- a/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
@@ -27,7 +27,7 @@ final class Slf4jLogger[F[_]: Sync](
     logger: JLogger,
     level: Level,
     formatter: Formatter,
-    syncType: Sync.Type = Sync.Type.Blocking
+    syncType: Sync.Type
 ) extends DefaultLogger[F](level) {
   override def submit(msg: LoggerMessage): F[Unit] = {
     Sync[F].uncancelable { _ =>
@@ -48,6 +48,7 @@ object Slf4jLogger {
   def apply[F[_]: Sync](
       logger: JLogger = LoggerFactory.getLogger("OdinSlf4jLogger"),
       level: Level = Level.Info,
-      formatter: Formatter = Formatter.default
-  ) = new Slf4jLogger[F](logger, level, formatter)
+      formatter: Formatter = Formatter.default,
+      syncType: Sync.Type = Sync.Type.Blocking
+  ) = new Slf4jLogger[F](logger, level, formatter, syncType)
 }


### PR DESCRIPTION
Avoids blocking the compute pool which can starve due to this/deliver less performance when its threads get blocked. Cats Effect's `Console` uses `blocking` as well, see https://github.com/typelevel/cats-effect/blob/66d829c8dac75949526bf9082175a12013dea7b1/std/shared/src/main/scala/cats/effect/std/ConsoleCrossPlatform.scala#L176

By making the type a param, users can restore the old behaviour of executing on the compute pool which is especially relevant if you use a slf4j logger that you know to be async.