### PR TITLE
Hide loggers' implementation details returning abstract `Logger[F]`

### DIFF
--- a/core/src/main/scala/io/odin/config/package.scala
+++ b/core/src/main/scala/io/odin/config/package.scala
@@ -32,26 +32,15 @@ package object config extends FileNamePatternSyntax {
     * Route logs to specific logger based on the fully qualified package name.
     * Beware of O(n) complexity due to the partial matching done during the logging
     */
-  def enclosureRouting[F[_]: Clock: Monad](router: (String, Logger[F])*): DefaultBuilder[F] = {
+  def enclosureRouting[F[_]: Clock: Monad](router: (String, Logger[F])*): DefaultBuilder[F] =
     new DefaultBuilder[F](new EnclosureRouting(_, router.toList))
-  }
 
   /**
     * Route logs to specific logger based on `Class[_]` instance. Beware of O(n) complexity due to the partial matching
     * done during the logging
     */
-  def classRouting[F[_]: Clock: Monad](
-      router: (Class[?], Logger[F])*
-  ): DefaultBuilder[F] =
-    new DefaultBuilder[F](
-      new EnclosureRouting(
-        _,
-        router.toList.map {
-          case (cls, logger) =>
-            cls.getName -> logger
-        }
-      )
-    )
+  def classRouting[F[_]: Clock: Monad](router: (Class[?], Logger[F])*): DefaultBuilder[F] =
+    enclosureRouting(router.map { case (cls, logger) => cls.getName -> logger }*)
 
   /**
     * Route logs based on their level

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -31,18 +31,18 @@ import cats.MonadThrow
   *
   * Use `AsyncLogger.withAsync` to instantiate it safely
   */
-case class AsyncLogger[F[_]: Clock](queue: Queue[F, LoggerMessage], timeWindow: FiniteDuration, inner: Logger[F])(
+final private[loggers] class AsyncLogger[F[_]: Clock](
+    queue: Queue[F, LoggerMessage],
+    inner: Logger[F]
+)(
     implicit F: MonadThrow[F]
 ) extends DefaultLogger[F](inner.minLevel) {
 
-  def submit(msg: LoggerMessage): F[Unit] = {
-    queue.tryOffer(msg).void
-  }
+  def withMinimalLevel(level: Level): Logger[F] = new AsyncLogger(queue, inner.withMinimalLevel(level))
 
-  private[loggers] def drain: F[Unit] =
-    drainAll.flatMap(msgs => inner.log(msgs.toList)).orElse(F.unit)
+  def submit(msg: LoggerMessage): F[Unit] = queue.tryOffer(msg).void
 
-  def withMinimalLevel(level: Level): Logger[F] = copy(inner = inner.withMinimalLevel(level))
+  private[loggers] def drain: F[Unit] = drainAll.flatMap(msgs => inner.log(msgs.toList)).voidError
 
   private def drainAll: F[Vector[LoggerMessage]] =
     F.tailRecM(Vector.empty[LoggerMessage]) { acc =>
@@ -72,6 +72,7 @@ object AsyncLogger {
   )(
       implicit F: Async[F]
   ): Resource[F, Logger[F]] = {
+
     val createQueue = maxBufferSize match {
       case Some(value) =>
         Queue.bounded[F, LoggerMessage](value)
@@ -81,14 +82,15 @@ object AsyncLogger {
 
     // Run internal loop of consuming events from the queue and push them down the chain
     def backgroundConsumer(logger: AsyncLogger[F]): Resource[F, Unit] = {
-      def drainLoop: F[Unit] = F.andWait(logger.drain, timeWindow).foreverM[Unit]
+
+      def drainLoop: F[Unit] = F.andWait(logger.drain, timeWindow).foreverM
 
       Resource.make(F.start(drainLoop))(fiber => logger.drain >> fiber.cancel).void
     }
 
     for {
       queue  <- Resource.eval(createQueue)
-      logger <- Resource.pure(AsyncLogger(queue, timeWindow, inner))
+      logger <- Resource.pure(new AsyncLogger(queue, inner))
       _      <- backgroundConsumer(logger)
     } yield logger
   }

--- a/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
@@ -21,21 +21,21 @@ import io.odin.{Level, Logger, LoggerMessage}
 import cats.effect.kernel.Clock
 import cats.Monad
 
-case class ConstContextLogger[F[_]: Clock: Monad](ctx: Map[String, String], inner: Logger[F])
+final private[loggers] class ConstContextLogger[F[_]: Clock: Monad](ctx: Map[String, String], inner: Logger[F])
     extends DefaultLogger(inner.minLevel) {
+
+  def withMinimalLevel(level: Level): Logger[F] = new ConstContextLogger(ctx, inner.withMinimalLevel(level))
 
   def submit(msg: LoggerMessage): F[Unit] = inner.log(msg.copy(context = msg.context ++ ctx))
 
   override def submit(msgs: List[LoggerMessage]): F[Unit] =
     inner.log(msgs.map(msg => msg.copy(context = msg.context ++ ctx)))
 
-  def withMinimalLevel(level: Level): Logger[F] = copy(inner = inner.withMinimalLevel(level))
-
 }
 
 object ConstContextLogger {
 
   def withConstContext[F[_]: Clock: Monad](ctx: Map[String, String], inner: Logger[F]): Logger[F] =
-    ConstContextLogger(ctx, inner)
+    new ConstContextLogger(ctx, inner)
 
 }

--- a/core/src/main/scala/io/odin/loggers/FilterLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/FilterLogger.scala
@@ -24,8 +24,11 @@ import cats.Monad
 /**
   * Filter each `LoggerMessage` using given predicate before passing it to the next logger
   */
-case class FilterLogger[F[_]: Clock](fn: LoggerMessage => Boolean, inner: Logger[F])(implicit F: Monad[F])
-    extends DefaultLogger[F](inner.minLevel) {
+final private[loggers] class FilterLogger[F[_]: Clock](fn: LoggerMessage => Boolean, inner: Logger[F])(
+    implicit F: Monad[F]
+) extends DefaultLogger[F](inner.minLevel) {
+
+  def withMinimalLevel(level: Level): Logger[F] = new FilterLogger(fn, inner.withMinimalLevel(level))
 
   def submit(msg: LoggerMessage): F[Unit] =
     F.whenA(fn(msg))(inner.log(msg))
@@ -33,6 +36,11 @@ case class FilterLogger[F[_]: Clock](fn: LoggerMessage => Boolean, inner: Logger
   override def submit(msgs: List[LoggerMessage]): F[Unit] =
     inner.log(msgs.filter(fn))
 
-  def withMinimalLevel(level: Level): Logger[F] = copy(inner = inner.withMinimalLevel(level))
+}
+
+object FilterLogger {
+
+  def withFilter[F[_]: Clock: Monad](fn: LoggerMessage => Boolean, inner: Logger[F]): Logger[F] =
+    new FilterLogger(fn, inner)
 
 }

--- a/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
@@ -25,13 +25,13 @@ import cats.Monad
 /**
   * Pure logger that stores logs in `WriterT` log
   */
-class WriterTLogger[F[_]: Clock: Monad](override val minLevel: Level = Level.Trace)
+final class WriterTLogger[F[_]: Clock: Monad](override val minLevel: Level = Level.Trace)
     extends DefaultLogger[WriterT[F, List[LoggerMessage], *]](minLevel) {
+
+  def withMinimalLevel(level: Level): Logger[WriterT[F, List[LoggerMessage], *]] = new WriterTLogger[F](level)
 
   def submit(msg: LoggerMessage): WriterT[F, List[LoggerMessage], Unit] = WriterT.tell(List(msg))
 
   override def submit(msgs: List[LoggerMessage]): WriterT[F, List[LoggerMessage], Unit] = WriterT.tell(msgs)
-
-  def withMinimalLevel(level: Level): Logger[WriterT[F, List[LoggerMessage], *]] = new WriterTLogger[F](level)
 
 }

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -50,9 +50,8 @@ package object odin {
       formatter: Formatter = Formatter.default,
       minLevel: Level = Level.Trace,
       openOptions: Seq[OpenOption] = Seq.empty
-  ): Resource[F, Logger[F]] = {
+  ): Resource[F, Logger[F]] =
     FileLogger(fileName, formatter, minLevel, openOptions)
-  }
 
   /**
     * Create logger with safe log files allocation suspended inside of `Resource`
@@ -78,9 +77,8 @@ package object odin {
       formatter: Formatter = Formatter.default,
       minLevel: Level = Level.Trace,
       openOptions: Seq[OpenOption] = Seq.empty
-  ): Resource[F, Logger[F]] = {
+  ): Resource[F, Logger[F]] =
     RollingFileLogger(fileNamePattern, maxFileSizeInBytes, rolloverInterval, formatter, minLevel, openOptions)
-  }
 
   /**
     * Create async logger with safe log file allocation and intermediate async buffer

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -73,13 +73,13 @@ package object syntax {
       * Modify logger message before it's written to the logger
       */
     def contramap(f: LoggerMessage => LoggerMessage)(implicit clock: Clock[F], F: Monad[F]): Logger[F] =
-      ContramapLogger(f, logger)
+      ContramapLogger.withContramap(f, logger)
 
     /**
       * Filter messages given the predicate. Falsified cases are dropped from the logging
       */
     def filter(f: LoggerMessage => Boolean)(implicit clock: Clock[F], F: Monad[F]): Logger[F] =
-      FilterLogger(f, logger)
+      FilterLogger.withFilter(f, logger)
 
     /**
       * Create logger that hashes context value given that context key matches one of the arguments
@@ -128,13 +128,13 @@ package object syntax {
       * Intercept logger message before it's written to the logger
       */
     def contramap(f: LoggerMessage => LoggerMessage)(implicit clock: Clock[F], F: Monad[F]): Resource[F, Logger[F]] =
-      resource.map(ContramapLogger(f, _))
+      resource.map(ContramapLogger.withContramap(f, _))
 
     /**
       * Filter messages given the predicate. Falsified cases are dropped from the logging
       */
     def filter(f: LoggerMessage => Boolean)(implicit clock: Clock[F], F: Monad[F]): Resource[F, Logger[F]] =
-      resource.map(FilterLogger(f, _))
+      resource.map(FilterLogger.withFilter(f, _))
 
     /**
       * Create logger that hashes context value given that context key matches one of the arguments

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -61,7 +61,7 @@ class AsyncLoggerSpec extends OdinSpec {
     forAll { (msgs: List[LoggerMessage]) =>
       (for {
         queue    <- Queue.unbounded[IO, LoggerMessage]
-        logger    = AsyncLogger(queue, 1.millis, Logger.noop[IO]).withMinimalLevel(Level.Trace)
+        logger    = new AsyncLogger(queue, Logger.noop[IO]).withMinimalLevel(Level.Trace)
         _        <- msgs.traverse(logger.log)
         reported <- List.fill(msgs.length)(queue.take).sequence
       } yield {
@@ -79,7 +79,7 @@ class AsyncLoggerSpec extends OdinSpec {
     forAll { (msgs: List[LoggerMessage]) =>
       (for {
         queue  <- Queue.unbounded[IO, LoggerMessage]
-        logger  = AsyncLogger(queue, 1.millis, errorLogger)
+        logger  = new AsyncLogger(queue, errorLogger)
         _      <- logger.log(msgs)
         result <- logger.drain
       } yield {

--- a/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
@@ -39,7 +39,7 @@ class ConsoleLoggerSpec extends OdinSpec {
         val errBaos = new ByteArrayOutputStream()
         val stdErr  = new PrintStream(errBaos)
 
-        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
+        val consoleLogger = new ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
         consoleLogger.log(loggerMessage).unsafeRunSync()
         outBaos.toString() shouldBe (formatter.format(loggerMessage) + System.lineSeparator())
       }
@@ -54,7 +54,7 @@ class ConsoleLoggerSpec extends OdinSpec {
         val errBaos = new ByteArrayOutputStream()
         val stdErr  = new PrintStream(errBaos)
 
-        val consoleLogger = ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
+        val consoleLogger = new ConsoleLogger[IO](formatter, stdOut, stdErr, Level.Trace, Sync.Type.Delay)
         consoleLogger.log(loggerMessage).unsafeRunSync()
         errBaos.toString() shouldBe (formatter.format(loggerMessage) + System.lineSeparator())
       }

--- a/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
@@ -40,8 +40,7 @@ class RollingFileLoggerSpec extends OdinSpec {
     IO.delay {
       ListDirectory(file).filter(_.isFile).foreach(_.delete())
       Files.delete(file)
-    }.attempt
-      .void
+    }.voidError
   }
 
   {

--- a/extras/src/main/scala/io/odin/extras/syntax/package.scala
+++ b/extras/src/main/scala/io/odin/extras/syntax/package.scala
@@ -36,7 +36,7 @@ package object syntax {
         minLevelOnError: Level,
         maxBufferSize: Option[Int] = None
     )(use: Logger[F] => F[A])(implicit F: Async[F]): F[A] =
-      ConditionalLogger.create[F](logger, minLevelOnError, maxBufferSize).use(use)
+      ConditionalLogger.withConditional[F](logger, minLevelOnError, maxBufferSize).use(use)
 
   }
 

--- a/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
@@ -28,8 +28,8 @@ case class BufferingLogger[F[_]](override val minLevel: Level)(implicit F: Sync[
 
   val buffer: Ref[F, Queue[LoggerMessage]] = Ref.unsafe[F, Queue[LoggerMessage]](Queue.empty)
 
-  def submit(msg: LoggerMessage): F[Unit] = buffer.update(_.enqueue(msg))
-
   def withMinimalLevel(level: Level): Logger[F] = copy(minLevel = level)
+
+  def submit(msg: LoggerMessage): F[Unit] = buffer.update(_.enqueue(msg))
 
 }

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -186,7 +186,7 @@ class Slf4jSpec extends OdinSpec {
     val errorSlf4JLogger                  = Slf4jLogger[IO](subLogger, Level.Error)
     val noErrorLogGen: Gen[LoggerMessage] = loggerMessageGen.filter(_.level < Level.Error)
     forAll(noErrorLogGen) { msg =>
-      errorSlf4JLogger.submit(msg).unsafeRunSync()
+      errorSlf4JLogger.log(msg).unsafeRunSync()
       logQueue.isEmpty shouldBe true
     }
   }


### PR DESCRIPTION
## Bin-incompat changes

- Hide concrete implementations' details by allowing construction only via companion object.
- Return always `Logger[F]` abstraction instead of concrete implementations.
- Use regular classes for loggers instead of case classes.

## Bin-compat changes

- Reuse some methods, avoiding duplication of code.
- Use built-in CE combinators for some common operations.