### PR TITLE
 Deprecate `BufferingLogger` 

### DIFF
--- a/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
@@ -24,6 +24,7 @@ import io.odin.loggers.DefaultLogger
 import cats.effect.kernel.Ref
 import cats.effect.Sync
 
+@deprecated("This logger will be moved to internal library test sources", "Odin 0.15.0")
 case class BufferingLogger[F[_]](override val minLevel: Level)(implicit F: Sync[F]) extends DefaultLogger[F](minLevel) {
 
   val buffer: Ref[F, Queue[LoggerMessage]] = Ref.unsafe[F, Queue[LoggerMessage]](Queue.empty)

--- a/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
@@ -16,6 +16,8 @@
 
 package io.odin.slf4j
 
+import scala.annotation.nowarn
+
 import io.odin.{Level, Logger}
 
 import cats.effect.kernel.Sync
@@ -23,6 +25,7 @@ import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
 import cats.effect.IO
 
+@nowarn("cat=deprecation&origin=io.odin.slf4j.BufferingLogger")
 class ExternalLogger extends OdinLoggerBinder[IO] {
 
   implicit val F: Sync[IO]                = IO.asyncForIO
@@ -34,8 +37,7 @@ class ExternalLogger extends OdinLoggerBinder[IO] {
     case Level.Info.toString  => new BufferingLogger[IO](Level.Info)
     case Level.Warn.toString  => new BufferingLogger[IO](Level.Warn)
     case Level.Error.toString => new BufferingLogger[IO](Level.Error)
-    case _ =>
-      new BufferingLogger[IO](Level.Trace)
+    case _                    => new BufferingLogger[IO](Level.Trace)
   }
 
 }

--- a/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
@@ -25,7 +25,7 @@ import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
 import cats.effect.IO
 
-@nowarn("cat=deprecation&origin=io.odin.slf4j.BufferingLogger")
+@nowarn("cat=deprecation&msg=This logger will be moved to internal library test sources")
 class ExternalLogger extends OdinLoggerBinder[IO] {
 
   implicit val F: Sync[IO]                = IO.asyncForIO

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -17,6 +17,7 @@
 package io.odin.slf4j
 
 import java.util.concurrent.LinkedBlockingQueue
+import scala.annotation.nowarn
 import scala.collection.immutable.Queue
 
 import io.odin.{Level, LoggerMessage, OdinSpec}
@@ -31,6 +32,7 @@ import org.slf4j.event.Level as JLevel
 import org.slf4j.event.SubstituteLoggingEvent
 import org.slf4j.helpers.SubstituteLogger
 
+@nowarn("cat=deprecation&origin=io.odin.slf4j.BufferingLogger")
 class Slf4jSpec extends OdinSpec {
 
   implicit private val ioRuntime: IORuntime = IORuntime.global

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -32,7 +32,7 @@ import org.slf4j.event.Level as JLevel
 import org.slf4j.event.SubstituteLoggingEvent
 import org.slf4j.helpers.SubstituteLogger
 
-@nowarn("cat=deprecation&origin=io.odin.slf4j.BufferingLogger")
+@nowarn("cat=deprecation&msg=This logger will be moved to internal library test sources")
 class Slf4jSpec extends OdinSpec {
 
   implicit private val ioRuntime: IORuntime = IORuntime.global


### PR DESCRIPTION
According to Git history, most probably, this class was only intended for test usage.

I'm going to move it to repository internal test sources, but first I want to give an opportunity to users to raise concerns if they use it in Production.