### PR TITLE
`AsyncLogger`: enqueue logging operation instead of a log message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,9 @@ lazy val cats = List(
   (version: String) => "org.typelevel" %% "cats-laws" % version % Test
 ).map(_.apply(versions.cats))
 
-lazy val catsEffect    = "org.typelevel" %% "cats-effect"     % versions.catsEffect
-lazy val catsEffectStd = "org.typelevel" %% "cats-effect-std" % versions.catsEffect
+lazy val catsEffect        = "org.typelevel" %% "cats-effect"         % versions.catsEffect
+lazy val catsEffectStd     = "org.typelevel" %% "cats-effect-std"     % versions.catsEffect
+lazy val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit" % versions.catsEffect % Test
 
 lazy val catsMtl = "org.typelevel" %% "cats-mtl" % versions.catsMtl
 
@@ -152,7 +153,7 @@ lazy val sharedSettings = Seq(
 lazy val `odin-core` = (project in file("core"))
   .settings(sharedSettings)
   .settings(
-    libraryDependencies ++= (catsEffect % Test) :: catsMtl :: sourcecode :: perfolation :: catsEffectStd :: alleycats :: cats
+    libraryDependencies ++= (catsEffect % Test) :: catsEffectTestkit :: catsMtl :: sourcecode :: perfolation :: catsEffectStd :: alleycats :: cats
   )
 
 lazy val `odin-json` = (project in file("json"))

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -76,7 +76,7 @@ object AsyncLogger {
     // Run internal loop of consuming events from the queue and push them down the chain
     def backgroundConsumer(logger: AsyncLogger[F]): Resource[F, Unit] = {
 
-      def drainLoop: F[Unit] = F.delayBy(logger.drain, timeWindow).foreverM
+      def drainLoop: F[Unit] = F.delayBy(F.uncancelable(_ => logger.drain), timeWindow).foreverM
 
       F.background(drainLoop).onFinalize(logger.drain).void
     }

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -33,7 +33,7 @@ class AsyncLoggerSpec extends OdinSpec {
   case class RefLogger(ref: Ref[IO, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
       extends DefaultLogger[IO](minLevel) {
 
-    def submit(msg: LoggerMessage): IO[Unit] = ref.update(_ :+ msg)
+    def submit(msg: LoggerMessage): IO[Unit] = IO.raiseError(new IllegalStateException("Async should always batch"))
 
     override def submit(msgs: List[LoggerMessage]): IO[Unit] = ref.update(_ ::: msgs)
 


### PR DESCRIPTION
Original upstream PR 👉🏽 https://github.com/valskalla/odin/pull/461

There are some differences between this PR and original one, the most notable one, not using a `Semaphore` around `drain`. AFAICS, `drain` is only called internally, and spaced by a time window. I don't see the reason to use permits, given that only one fiber (the background loop) will be calling it.

The part that concerns me is the benchmark. Here we're trading performance for correctness, which is a good point, but I'd like to hear some users' thoughts about it.

Now the results, following the same approach as upstream PR:

## 1) AsyncLoggerBenchmark
### Before
```
[info] Benchmark                             Mode  Cnt     Score     Error  Units
[info] AsyncLoggerBenchmark.msg              avgt   25  1635.576 ± 145.618  ns/op
[info] AsyncLoggerBenchmark.msgAndCtx        avgt   25  1713.306 ± 209.162  ns/op
[info] AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  2002.529 ± 939.309  ns/op
```

### After
```
[info] Benchmark                             Mode  Cnt     Score      Error  Units
[info] AsyncLoggerBenchmark.msg              avgt   25  1803.819 ±  159.555  ns/op
[info] AsyncLoggerBenchmark.msgAndCtx        avgt   25  1895.908 ±  412.442  ns/op
[info] AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  3095.106 ± 1259.061  ns/op
```

## 2) Measure the cost of the `drain` operation
### Before
```
[info] Benchmark                             Mode  Cnt     Score     Error  Units
[info] AsyncLoggerBenchmark.msg              avgt   25  1607.056 ± 266.458  ns/op
[info] AsyncLoggerBenchmark.msgAndCtx        avgt   25  1587.006 ± 133.531  ns/op
[info] AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  6903.186 ± 186.564  ns/op
```

### After
```
[info] Benchmark                             Mode  Cnt     Score     Error  Units
[info] AsyncLoggerBenchmark.msg              avgt   25  4044.233 ± 126.506  ns/op
[info] AsyncLoggerBenchmark.msgAndCtx        avgt   25  4215.031 ± 111.849  ns/op
[info] AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  9383.689 ± 216.399  ns/op
```

cc @iRevive @ybasket 