### PR TITLE
`AsyncLogger`: semantic blocking instead of poll loop

### DIFF
--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -42,9 +42,6 @@ private[loggers] final class AsyncLogger[F[_]](
     // Forbid cancellation after taking some elements from the queue
     F.uncancelable { poll => poll(buffer.take).flatMap(head => drain(Some(head))) }
 
-  /**
-    * Same as `blockingDrain` but without semantically blocking
-    */
   def drain(head: Option[(Logger[F], LoggerMessage)]): F[Unit] =
     buffer
       .tryTakeN(None)

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -84,26 +84,23 @@ package object odin {
     * Create async logger with safe log file allocation and intermediate async buffer
     * @param fileName name of log file to append to
     * @param formatter formatter to use
-    * @param timeWindow pause between async buffer flushing
     * @param maxBufferSize maximum buffer size
     * @param minLevel minimal level of logs to be printed
     */
   def asyncFileLogger[F[_]: Async](
       fileName: String,
       formatter: Formatter = Formatter.default,
-      timeWindow: FiniteDuration = 1.second,
       maxBufferSize: Option[Int] = None,
       minLevel: Level = Level.Trace,
       openOptions: Seq[OpenOption] = Seq.empty
   ): Resource[F, Logger[F]] =
-    fileLogger[F](fileName, formatter, minLevel, openOptions).withAsync(timeWindow, maxBufferSize)
+    fileLogger[F](fileName, formatter, minLevel, openOptions).withAsync(maxBufferSize)
 
   /**
     * Same as [[rollingFileLogger]] but with intermediate async buffer
     * @param fileNamePattern function that provides a path to a log file given a current local datetime
     * @param rolloverInterval interval for rollover. When set, new log file is created each time interval is over
     * @param maxFileSizeInBytes max size of log file. When set, new log file is created each time the current log file size exceeds the setting
-    * @param timeWindow pause between async buffer flushing
     * @param maxBufferSize maximum buffer size
     * @param formatter formatter to use
     * @param minLevel minimal level of logs to be printed
@@ -112,13 +109,12 @@ package object odin {
       fileNamePattern: LocalDateTime => String,
       rolloverInterval: Option[FiniteDuration],
       maxFileSizeInBytes: Option[Long],
-      timeWindow: FiniteDuration = 1.second,
       maxBufferSize: Option[Int] = None,
       formatter: Formatter = Formatter.default,
       minLevel: Level = Level.Trace,
       openOptions: Seq[OpenOption] = Seq.empty
   ): Resource[F, Logger[F]] =
     rollingFileLogger(fileNamePattern, rolloverInterval, maxFileSizeInBytes, formatter, minLevel, openOptions)
-      .withAsync(timeWindow, maxBufferSize)
+      .withAsync(maxBufferSize)
 
 }

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -16,10 +16,7 @@
 
 package io.odin
 
-import scala.concurrent.duration.*
-
 import io.odin.loggers.*
-import io.odin.loggers.{AsyncLogger, ConstContextLogger, ContextualLogger, ContramapLogger, FilterLogger, WithContext}
 import io.odin.meta.Render
 
 import cats.effect.kernel.{Async, Clock, Resource}
@@ -45,29 +42,21 @@ package object syntax {
       ContextualLogger.withContext(logger)
 
     /**
-      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain each `timeWindow`
-      * @param timeWindow pause between async buffer flushing
+      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain asynchronously
       * @param maxBufferSize max logs buffer size
       * @return Logger suspended in `Resource`. Once this `Resource` started, internal flush loop is initialized. Once
       *         resource is released, flushing is also stopped.
       */
-    def withAsync(
-        timeWindow: FiniteDuration = 1.millis,
-        maxBufferSize: Option[Int] = None
-    )(implicit F: Async[F]): Resource[F, Logger[F]] =
-      AsyncLogger.withAsync(logger, timeWindow, maxBufferSize)
+    def withAsync(maxBufferSize: Option[Int] = None)(implicit F: Async[F]): Resource[F, Logger[F]] =
+      AsyncLogger.withAsync(logger, maxBufferSize)
 
     /**
       * Create and unsafely run async logger that buffers the messages up to the limit (if any) and
-      * flushes it down the chain each `timeWindow`
-      * @param timeWindow  pause between async buffer flushing
+      * flushes it down the chain asynchronously
       * @param maxBufferSize max logs buffer size
       */
-    def withAsyncUnsafe(
-        timeWindow: FiniteDuration = 1.millis,
-        maxBufferSize: Option[Int] = None
-    )(implicit F: Async[F], dispatcher: Dispatcher[F]): Logger[F] =
-      AsyncLogger.withAsyncUnsafe(logger, timeWindow, maxBufferSize)
+    def withAsyncUnsafe(maxBufferSize: Option[Int] = None)(implicit F: Async[F], dispatcher: Dispatcher[F]): Logger[F] =
+      AsyncLogger.withAsyncUnsafe(logger, maxBufferSize)
 
     /**
       * Modify logger message before it's written to the logger
@@ -98,17 +87,13 @@ package object syntax {
   implicit class ResourceLoggerSyntax[F[_]](resource: Resource[F, Logger[F]]) {
 
     /**
-      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain each `timeWindow`
-      * @param timeWindow pause between async buffer flushing
+      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain asynchronously
       * @param maxBufferSize max logs buffer size
       * @return Logger suspended in `Resource`. Once this `Resource` started, internal flush loop is initialized. Once
       *         resource is released, flushing is also stopped.
       */
-    def withAsync(
-        timeWindow: FiniteDuration = 1.millis,
-        maxBufferSize: Option[Int] = None
-    )(implicit F: Async[F]): Resource[F, Logger[F]] =
-      resource.flatMap(AsyncLogger.withAsync(_, timeWindow, maxBufferSize))
+    def withAsync(maxBufferSize: Option[Int] = None)(implicit F: Async[F]): Resource[F, Logger[F]] =
+      resource.flatMap(AsyncLogger.withAsync(_, maxBufferSize))
 
     /**
       * Create logger that adds constant context to each log record

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -80,7 +80,7 @@ class AsyncLoggerSpec extends OdinSpec {
         buffer <- Queue.unbounded[IO, (Logger[IO], LoggerMessage)]
         logger  = new AsyncLogger(buffer, errorLogger)
         _      <- logger.log(msgs)
-        result <- logger.drain.unlessA(msgs.isEmpty)
+        result <- logger.blockingDrain.unlessA(msgs.isEmpty)
       } yield {
         result shouldBe ()
       }).unsafeRunSync()
@@ -96,9 +96,9 @@ class AsyncLoggerSpec extends OdinSpec {
         logger        = new AsyncLogger(buffer, RefLogger(ref, Level.Info))
         traceLogger   = logger.withMinimalLevel(Level.Trace)
         _            <- msgs.traverse(logger.log)      // only Info, Warn, Error messages should be logged
-        _            <- logger.tryDrain
+        _            <- logger.drain(None)
         _            <- msgs.traverse(traceLogger.log) // all messages should be logged
-        _            <- logger.tryDrain
+        _            <- logger.drain(None)
         reported     <- ref.get
       } yield {
         val (infos, all) = reported.splitAt(infoMessages.size)

--- a/docs/README.md
+++ b/docs/README.md
@@ -405,15 +405,11 @@ as well as controllable in-memory buffering for logs before they're flushed down
 Definition of `withAsync` is following:
 
 ```scala
-def withAsync(
-               timeWindow: FiniteDuration = 1.millis,
-               maxBufferSize: Option[Int] = None
-             )(implicit F: Async[F]): Resource[F, Logger[F]]
+def withAsync(maxBufferSize: Option[Int] = None)(implicit F: Async[F]): Resource[F, Logger[F]]
 ```
 
 Following parameters are configurable if default ones don't fit:
 
-- Time period between flushed, default is 1 millisecond
 - Maximum underlying buffer size, by default buffer is unbounded.
 
 ## Class and enclosure routing

--- a/zio/src/main/scala-2/io/odin/zio/package.scala
+++ b/zio/src/main/scala-2/io/odin/zio/package.scala
@@ -17,7 +17,6 @@
 package io.odin
 
 import scala.annotation.nowarn
-import scala.concurrent.duration.*
 
 import io.odin.formatter.Formatter
 
@@ -71,7 +70,6 @@ package object zio {
   def asyncFileLogger(
       fileName: String,
       formatter: Formatter = Formatter.default,
-      timeWindow: FiniteDuration = 1.second,
       maxBufferSize: Option[Int] = None,
       minLevel: Level = Level.Trace
   ): ZManaged[Clock & Blocking, LoggerError, Logger[IO[LoggerError, *]]] =
@@ -80,7 +78,7 @@ package object zio {
       .flatMap { implicit F =>
         ZManaged.fromEffect {
           Dispatcher.sequential[Task].use { implicit dispatcher =>
-            Task(io.odin.asyncFileLogger[Task](fileName, formatter, timeWindow, maxBufferSize, minLevel).toManaged)
+            Task(io.odin.asyncFileLogger[Task](fileName, formatter, maxBufferSize, minLevel).toManaged)
           }
         }
       }

--- a/zio/src/main/scala-3/io/odin/zio/zio.scala
+++ b/zio/src/main/scala-3/io/odin/zio/zio.scala
@@ -17,7 +17,6 @@
 package io.odin
 
 import scala.annotation.nowarn
-import scala.concurrent.duration.*
 
 import io.odin.formatter.Formatter
 
@@ -70,7 +69,6 @@ package object zio {
   def asyncFileLogger(
       fileName: String,
       formatter: Formatter = Formatter.default,
-      timeWindow: FiniteDuration = 1.second,
       maxBufferSize: Option[Int] = None,
       minLevel: Level = Level.Trace
   ): ZManaged[Clock & Blocking, LoggerError, Logger[IO[LoggerError, *]]] =
@@ -79,7 +77,7 @@ package object zio {
       .flatMap { implicit F =>
         ZManaged.fromEffect {
           Dispatcher.sequential[Task].use { implicit dispatcher =>
-            Task(io.odin.asyncFileLogger[Task](fileName, formatter, timeWindow, maxBufferSize, minLevel).toManaged)
+            Task(io.odin.asyncFileLogger[Task](fileName, formatter, maxBufferSize, minLevel).toManaged)
           }
         }
       }


### PR DESCRIPTION
Fixes #41 