### PR TITLE
Fix slf4j 2.0 example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,11 +793,11 @@ import cats.effect.{Sync, IO}
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
 import io.odin._
-import io.odin.slf4j.OdinLoggerBinder
+import io.odin.slf4j.OdinLoggerServiceProvider
 
 //effect type should be specified inbefore
 //log line will be recorded right after the call with no suspension
-class ExternalLogger extends OdinLoggerBinder[IO] {
+class ExternalLogger extends OdinLoggerServiceProvider[IO] {
 
   implicit val F: Sync[IO] = IO.asyncForIO
   implicit val dispatcher: Dispatcher[IO] = Dispatcher.sequential[IO].allocated.unsafeRunSync()._1


### PR DESCRIPTION
The sample code still referenced a class from the slf4j 1.7 module.