### PR TITLE
Structured JSON format for Elastic Common Schema

### DIFF
--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -144,7 +144,7 @@ object Formatter {
     */
   def formatPositionAsClassAndMethod(position: Position): Option[(String, String)] =
     position.enclosureName.split('#') match {
-      case Array(logger, name) => Some((logger, name))
+      case Array(fqdn, method) => Some((fqdn, method))
       case _                   => None
     }
 

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -140,6 +140,21 @@ object Formatter {
   }
 
   /**
+    * Extracts class and method names from position
+    */
+  def formatPositionAsClassAndMethod(position: Position): Option[(String, String)] =
+    position.enclosureName.split('#') match {
+      case Array(logger, name) => Some((logger, name))
+      case _                   => None
+    }
+
+  def formatPositionAsFileName(position: Position): String =
+    position.fileName.lastIndexOf('/') match {
+      case -1  => position.fileName
+      case idx => position.fileName.substring(idx + 1)
+    }
+
+  /**
     * Default Throwable printer is twice as slow. This method was borrowed from scribe library.
     *
     * The result differs depending on the format:

--- a/json/src/main/scala/io/odin/json/Formatter.scala
+++ b/json/src/main/scala/io/odin/json/Formatter.scala
@@ -27,12 +27,30 @@ object Formatter {
 
   val json: OFormatter = create(ThrowableFormat.Default, PositionFormat.Full)
 
+  val ecsJson: OFormatter = { (msg: LoggerMessage) =>
+    val classAndMethod = formatPositionAsClassAndMethod(msg.position)
+    writeToString(
+      Output.ECS(
+        formatTimestamp(msg.timestamp),
+        msg.message.value,
+        msg.context,
+        msg.level,
+        classAndMethod.map(_._1),
+        msg.position.line,
+        formatPositionAsFileName(msg.position),
+        classAndMethod.map(_._2),
+        msg.threadName,
+        msg.exception.map(t => formatThrowable(t, ThrowableFormat.Default))
+      )
+    )
+  }
+
   def create(throwableFormat: ThrowableFormat): OFormatter =
     create(throwableFormat, PositionFormat.Full)
 
   def create(throwableFormat: ThrowableFormat, positionFormat: PositionFormat): OFormatter = { (msg: LoggerMessage) =>
     writeToString(
-      Output(
+      Output.Default(
         msg.level,
         msg.message.value,
         msg.context,

--- a/json/src/main/scala/io/odin/json/Output.scala
+++ b/json/src/main/scala/io/odin/json/Output.scala
@@ -22,17 +22,36 @@ import cats.syntax.show.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
 
-private[json] final case class Output(
-    level: Level,
-    message: String,
-    context: Map[String, String],
-    exception: Option[String],
-    position: String,
-    threadName: String,
-    timestamp: String
-)
-
 object Output {
+
+  private[json] final case class Default(
+      level: Level,
+      message: String,
+      context: Map[String, String],
+      exception: Option[String],
+      position: String,
+      threadName: String,
+      timestamp: String
+  )
+
+  /**
+    * Elastic Common Schema fields
+    *
+    * @see [[https://www.elastic.co/guide/en/ecs/current/ecs-guidelines.html ECS Guidelines]]
+    * @see [[https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html ECS Field Reference]]
+    */
+  private[json] final case class ECS(
+      `@timestamp`: String,
+      message: String,
+      labels: Map[String, String],
+      `log.level`: Level,
+      `log.logger`: Option[String],
+      `log.origin.file.line`: Int,
+      `log.origin.file.name`: String,
+      `log.origin.function`: Option[String],
+      `process.thread.name`: String,
+      `error.stack_trace`: Option[String]
+  )
 
   private[json] implicit val levelCodec: JsonValueCodec[Level] = new JsonValueCodec[Level] {
 
@@ -45,7 +64,9 @@ object Output {
 
   }
 
-  private[json] implicit val codec: JsonValueCodec[Output] =
+  private[json] implicit val defaultCodec: JsonValueCodec[Default] =
     JsonCodecMaker.make(CodecMakerConfig.withFieldNameMapper(JsonCodecMaker.enforce_snake_case))
+
+  private[json] implicit val ecsCodec: JsonValueCodec[ECS] = JsonCodecMaker.make
 
 }

--- a/json/src/test/scala/io/odin/json/FormatterSpec.scala
+++ b/json/src/test/scala/io/odin/json/FormatterSpec.scala
@@ -57,4 +57,37 @@ class FormatterSpec extends OdinSpec {
     }
   }
 
+  "ecsJson.format" should "generate correct json" in {
+    def jsonMethod = Formatter.ecsJson.format(
+      LoggerMessage(
+        Level.Info,
+        Eval.later("just a test"),
+        Map("a" -> "field"),
+        Some(new Exception("test exception")),
+        Position.derivePosition,
+        "test-thread-1",
+        Instant.EPOCH.toEpochMilli
+      )
+    )
+
+    val jsonString = jsonMethod
+
+    jsonString should include(""""@timestamp":"1970-01-01""")
+    jsonString should include(""""message":"just a test"""")
+    jsonString should include(""""labels":{"a":"field"}""")
+    jsonString should include(""""log.level":"INFO"""")
+    jsonString should include(""""log.logger":"io.odin.json.FormatterSpec"""")
+    jsonString should include(""""log.origin.file.line":67""")
+    jsonString should include(""""log.origin.file.name":"FormatterSpec.scala"""")
+    jsonString should include(""""log.origin.function":"jsonMethod"""")
+    jsonString should include(""""process.thread.name":"test-thread-1"""")
+    jsonString should include(""""error.stack_trace":"Caused by: java.lang.Exception: test exception""")
+  }
+
+  it should "serialize any LoggerMessage" in {
+    forAll(loggerMessageGen) { m =>
+      noException should be thrownBy Formatter.ecsJson.format(m)
+    }
+  }
+
 }


### PR DESCRIPTION
At $WORK we use Elastic Search with structured JSON logging.

I found that providing a formatter for ECS would be useful for others.