### PR TITLE
Fix default format for `Slf4jLogger`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.19"
+ThisBuild / tlBaseVersion := "0.20"
 
 ThisBuild / organization     := "dev.scalafreaks"
 ThisBuild / organizationName := "ScalaFreaks"

--- a/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/Slf4jLogger.scala
@@ -35,15 +35,23 @@ private[slf4j] final class Slf4jLogger[F[_]: Sync](
 
   def submit(msg: LoggerMessage): F[Unit] = {
     Sync[F].uncancelable { _ =>
-      Sync[F].whenA(msg.level >= this.minLevel)(msg.level match {
-        case Level.Trace => Sync[F].suspend(syncType)(logger.trace(formatter.format(msg)))
-        case Level.Debug => Sync[F].suspend(syncType)(logger.debug(formatter.format(msg)))
-        case Level.Info  => Sync[F].suspend(syncType)(logger.info(formatter.format(msg)))
-        case Level.Warn  => Sync[F].suspend(syncType)(logger.warn(formatter.format(msg)))
-        case Level.Error => Sync[F].suspend(syncType)(logger.error(formatter.format(msg)))
+      Sync[F].whenA(msg.level >= this.minLevel)((msg.level, msg.exception) match {
+        case (Level.Trace, None)    => forward(msg)(logger.trace)
+        case (Level.Trace, Some(t)) => forward(msg)(logger.trace(_, t))
+        case (Level.Debug, None)    => forward(msg)(logger.debug)
+        case (Level.Debug, Some(t)) => forward(msg)(logger.debug(_, t))
+        case (Level.Info, None)     => forward(msg)(logger.info)
+        case (Level.Info, Some(t))  => forward(msg)(logger.info(_, t))
+        case (Level.Warn, None)     => forward(msg)(logger.warn)
+        case (Level.Warn, Some(t))  => forward(msg)(logger.warn(_, t))
+        case (Level.Error, None)    => forward(msg)(logger.error)
+        case (Level.Error, Some(t)) => forward(msg)(logger.error(_, t))
       })
     }
   }
+
+  private def forward(msg: LoggerMessage)(log: String => Unit): F[Unit] =
+    Sync[F].suspend(syncType)(log(formatter.format(msg)))
 
 }
 
@@ -52,7 +60,7 @@ object Slf4jLogger {
   def apply[F[_]: Sync](
       logger: JLogger = LoggerFactory.getLogger("OdinSlf4jLogger"),
       level: Level = Level.Info,
-      formatter: Formatter = Formatter.default,
+      formatter: Formatter = msg => msg.message.value,
       syncType: Sync.Type = Sync.Type.Blocking
   ): Logger[F] = new Slf4jLogger[F](logger, level, formatter, syncType)
 


### PR DESCRIPTION
The default format is duplicating fields unnecessarily